### PR TITLE
test for no rsvp message and test for adding event

### DIFF
--- a/cypress/e2e/app.cy.js
+++ b/cypress/e2e/app.cy.js
@@ -28,7 +28,7 @@ describe("app", () => {
       .get(".event-card").contains("p", "Taking our 3yo to the park")
       .get(".toggle-button").click()
       .get(".modal").contains("h2", "Picnic in the park")
-      .get(".close-modal").click({force: true})
+      .get(".close-modal").click()
       .get(".modal").should("not.be.visible")
   })
 

--- a/cypress/e2e/rsvp.cy.js
+++ b/cypress/e2e/rsvp.cy.js
@@ -1,0 +1,24 @@
+/// <reference types="cypress" />
+
+
+describe("app", () => {
+  beforeEach(() => {
+    cy.visit("http://localhost:3000/rsvp")
+  })
+
+  it("should have a message on load that says the user has no RSVPs", () => {
+    cy.get(".no-events-message").contains("You have not RSVP'd to any events! Go check some out!")
+  })
+
+  it("should be able to click home and select event and rsvp to it and have it show on the RSVP page", () => {
+    cy.get(".nav-links").contains("Home").click()
+      .url().should("eq", "http://localhost:3000/home")
+      .get(".menu-container").contains("North West").click()
+      .get(".content").contains("89129").click()
+      .get(".toggle-button").click()
+      .get(".rsvp-button").click()
+      .get(".nav-links").contains("RSVP").click()
+      .get(".event-card").contains("h3", "Picnic in the park")
+
+  })
+})

--- a/src/Components/Events/Events.js
+++ b/src/Components/Events/Events.js
@@ -21,7 +21,7 @@ const Events = ({type, filteredEvents, toggleModal, messageByType}) => {
 
   return (
     <div className="events-container">
-      {renderedEvents.length ? renderedEvents : <p>{messageByType(type)}</p>}
+      {renderedEvents.length ? renderedEvents : <p className="no-events-message">{messageByType(type)}</p>}
     </div>
   )
 }


### PR DESCRIPTION
## Summary:
Test RSVP page for no event message and when an event is added.

Future: test delete function.

## Type of Changes:
- [ ] Bug fix
- [ ] Refactor
- [x] New feature


## How was this tested:
Cypress

## What are the relevant tickets:
closes #26 